### PR TITLE
Add search paths to look for sifters in multiple places

### DIFF
--- a/xsiftx/__init__.py
+++ b/xsiftx/__init__.py
@@ -18,4 +18,4 @@ as the first three arguments.  All other arguments passed to xsiftx.py are
 passed along as is.
 """
 
-VERSION = "0.1.2"
+VERSION = "0.2.0"

--- a/xsiftx/command_line.py
+++ b/xsiftx/command_line.py
@@ -33,14 +33,16 @@ def execute():
     """
     Begin command processing
     """
-    sifter_list = get_sifters()
+    sifter_dict = get_sifters()
     parser = argparse.ArgumentParser(
         prog='xsiftx.py',
         formatter_class=argparse.RawTextHelpFormatter,
-        description=('Run a sifter against one or all courses.\n'
-                     'Current available sifters:\n{0}'.format(
-                         '\n'.join(sifter_list))
-                 )
+        description=(
+            'Run a sifter against one or all courses.\n'
+            'Current available sifters:\n{0}'.format(
+                '\n'.join(sifter_dict.keys())
+            )
+        )
     )
     parser.add_argument('sifter',
                         help='script in sifter library to run')
@@ -56,7 +58,7 @@ def execute():
 
     args = parser.parse_args()
 
-    if args.sifter not in sifter_list:
+    if args.sifter not in sifter_dict.keys():
         sys.stderr.write("You have specified a sifter that doesn't exist\n")
         sys.exit(-1)
 
@@ -75,8 +77,7 @@ def execute():
 
     # Everything is all setup, now run the sifter and write the output
     # to the grade download location.
-    sifter_path = '{0}/{1}'.format(os.path.dirname(xsiftx.sifters.__file__),
-                                   args.sifter)
+
     data_store = None
     if settings['use_s3']:
         data_store = xsiftx.store.S3Store(settings)
@@ -92,7 +93,12 @@ def execute():
     for course in courses_to_run:
         with tempfile.NamedTemporaryFile() as tmpfile:
             with tempfile.NamedTemporaryFile() as stderr_tmp:
-                cmd = [sifter_path, args.venv, args.edx_platform, course, ]
+                cmd = [
+                    sifter_dict[args.sifter],
+                    args.venv,
+                    args.edx_platform,
+                    course,
+                    ]
                 cmd.extend(args.extra_args)
                 sift = subprocess.Popen(cmd, stdout=tmpfile, stderr=stderr_tmp,
                                         universal_newlines=True)

--- a/xsiftx/util.py
+++ b/xsiftx/util.py
@@ -18,18 +18,28 @@ def get_sifters():
     Get list of currently installed sifters
     """
 
-    sifter_list = []
-    sifter_path = os.path.dirname(xsiftx.sifters.__file__)
-    executable = stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
-    for filename in os.listdir(sifter_path):
-        fullpath = os.path.join(sifter_path, filename)
-        if os.path.isfile(fullpath):
-            fstat = os.stat(fullpath)
-            mode = fstat.st_mode
-            if mode & executable:
-                sifter_list.append(filename)
+    sifter_dict = {}
+    # List of paths to look for sifters, ordered
+    # in reverse precedence (most important last)
+    # to replace sifter dictionary
+    sifter_paths = [
+        os.path.dirname(xsiftx.sifters.__file__),  # Installed sifters
+        os.path.join(os.path.expanduser('~'), 'sifters'),  # HOME_DIR sifters
+        os.path.join(os.getcwd(), 'sifters'),  # cwd sifters
+    ]
 
-    return sifter_list
+    executable = stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+    for sifter_path in sifter_paths:
+        if os.path.isdir(sifter_path):
+            for filename in os.listdir(sifter_path):
+                fullpath = os.path.join(sifter_path, filename)
+                if os.path.isfile(fullpath):
+                    fstat = os.stat(fullpath)
+                    mode = fstat.st_mode
+                    if mode & executable:
+                        sifter_dict[filename] = fullpath
+
+    return sifter_dict
 
 
 def get_course_list(venv, edx_root):
@@ -57,6 +67,7 @@ def get_course_list(venv, edx_root):
         )
         sys.exit(-1)
     return course_raw.split('\n')[:-1]
+
 
 def get_settings(edx_root):
     """


### PR DESCRIPTION
This enables the option to have sifters outside of the installed
application.  It searches the installed location, then your home
directory (~/sifters/) then the current working directory ( $(pwd)/sifters)
and if there is name collision prefers the closer sifter.

Resolves #2
