### PR TITLE
Adds an additional search path for sifters inside the common

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,16 @@ Several sifters are provided in this repository:
   feature flag `REMOTE_GRADEBOOK_URL`.  It optionally takes an
   assignment name, but will post grades for every assignment if one
   isn't specified.
+
+
+## Adding additional sifters ##
+
+In addition to the provided sifters, you can add additional sifters
+via a couple methods.  The command searches for executable files first
+in the installation, then at a system location
+`/usr/local/share/xsiftx/sifters`, then in a user directory
+`~/sifters`, then in your current directory `$(cwd)/sifters`, and
+finally by an environment variable `SIFTER_DIR`.  The order of
+preference is first to last from above, so if you have a sifter with
+the same name in `SIFTER_DIR` and `~/sifters`, the one in `SIFTER_DIR`
+would be what is called by xsiftx.

--- a/xsiftx/util.py
+++ b/xsiftx/util.py
@@ -43,6 +43,7 @@ def get_sifters():
     # to replace sifter dictionary
     sifter_paths = [
         os.path.dirname(xsiftx.sifters.__file__),  # Installed sifters
+        os.path.dirname('/usr/local/share/xsiftx/sifters'),  # System sifters
         os.path.join(os.path.expanduser('~'), 'sifters'),  # HOME_DIR sifters
         os.path.join(os.getcwd(), 'sifters'),  # cwd sifters
         os.environ.get('SIFTER_DIR', ''),  # Environment set sifters


### PR DESCRIPTION
Adds common /usr/local/share/xsiftx/sifters directory for easier adding
of system wide sifters.
